### PR TITLE
Adding loaders to QueryConfig

### DIFF
--- a/src/main/scala/com/googlecode/mapperdao/QueryConfig.scala
+++ b/src/main/scala/com/googlecode/mapperdao/QueryConfig.scala
@@ -35,7 +35,8 @@ case class QueryConfig(
 	// within a transaction.
 	multi: MultiThreadedConfig = MultiThreadedConfig.Single,
 	hints: SelectHints = SelectHints.None,
-	schemaModifications: SchemaModifications = SchemaModifications.NoOp
+	schemaModifications: SchemaModifications = SchemaModifications.NoOp,
+  manyToManyCustomLoaders: List[CustomLoader[_, _, _]] = Nil
 	)
 {
 

--- a/src/main/scala/com/googlecode/mapperdao/SelectConfig.scala
+++ b/src/main/scala/com/googlecode/mapperdao/SelectConfig.scala
@@ -41,7 +41,8 @@ object SelectConfig
 			cacheOptions = queryConfig.cacheOptions,
 			lazyLoad = queryConfig.lazyLoad,
 			hints = queryConfig.hints,
-			schemaModifications = queryConfig.schemaModifications
+			schemaModifications = queryConfig.schemaModifications,
+      manyToManyCustomLoaders = queryConfig.manyToManyCustomLoaders
 		)
 
 	def lazyLoad = SelectConfig(lazyLoad = LazyLoad.all)


### PR DESCRIPTION
Hi Kostas,

It's Sinan from Peerius. I have added the ability to include loaders for a QueryConfig. Without this we are not able to keep our cache in sync when the QueryDao is used to retrieve products.